### PR TITLE
Save stormlash banner rotation in db at raid setup import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Sleepo
+
+## v1.1.1 (20/08/2025)
+
+- Raid Setup Importer now saves the Stormlash and Banner Rotation in the addon database, instead of pushing it to WeakAuras, allowing to persist the rotation between sessions/reloads. An event WA_SLEEPO_NEW_SB_ROTATION is triggered when a new rotation has been saved, and rotation can be retrieved using Sleepo.DB:get("StormlashBannerRotation")

--- a/Interface/Raid/RaidSetupImporter.lua
+++ b/Interface/Raid/RaidSetupImporter.lua
@@ -138,9 +138,9 @@ function RaidSetupImporter:ParseJSON(text, frame)
         end
     end
 
-    WeakAuras.ScanEvents("WA_SLEEPO_SAVE_SB_ROTATION", rotationTable)
-    DevTools_Dump(rotationTable)
-    SP:message("Stormlash and Banner rotations event sent")
+    Sleepo.DB:set("StormlashBannerRotation", rotationTable)
+    WeakAuras.ScanEvents("WA_SLEEPO_NEW_SB_ROTATION")
+    SP:message("Stormlash and Banner rotation saved")
 end
 
 --- Close the import window

--- a/Sleepo.toc
+++ b/Sleepo.toc
@@ -2,7 +2,7 @@
 ## Title: Sleepo Manager
 ## RequiredDeps: WeakAuras
 ## SavedVariables: SleepoDB
-## Version: 1.1.0
+## Version: 1.1.1
 
 # Libs
 libraries.xml

--- a/pkgmeta.yaml
+++ b/pkgmeta.yaml
@@ -1,2 +1,4 @@
+changelog: CHANGELOG.md
+
 ignore:
   - .vscode


### PR DESCRIPTION
# Sleepo

## v1.1.1 (20/08/2025)

- Raid Setup Importer now saves the Stormlash and Banner Rotation in the addon database, instead of pushing it to WeakAuras, allowing to persist the rotation between sessions/reloads. An event WA_SLEEPO_NEW_SB_ROTATION is triggered when a new rotation has been saved, and rotation can be retrieved using Sleepo.DB:get("StormlashBannerRotation")